### PR TITLE
bugfix for month rollover on subtraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function monthMath(date, val){
 
     date = dates.month(date, newMonth)
 
-    if (newMonth < 0 ) newMonth = 12 + val
+    while (newMonth < 0 ) newMonth = 12 + newMonth
       
     //month rollover
     if ( dates.month(date) !== ( newMonth % 12))

--- a/test.js
+++ b/test.js
@@ -45,6 +45,7 @@ assert.equal(+dateMath.add(date, 1, 'hours'),   +(new Date(2014, 1, 18, 9, 25, 3
 assert.equal(+dateMath.add(date, 1, 'minutes'), +(new Date(2014, 1, 18, 8, 26, 30, 5)), 'add minutes')
 assert.equal(+dateMath.add(date, 1, 'seconds'), +(new Date(2014, 1, 18, 8, 25, 31, 5)), 'add seconds')
 assert.equal(+dateMath.add(date, 1, 'milliseconds'), +(new Date(2014, 1, 18, 8, 25, 30, 6)), 'add milliseconds')
+assert.equal(+dateMath.subtract(date, 24, 'month'), +dateMath.subtract(date, 2, 'year'), 'month rollover')
 
 assert.equal(+dateMath.max(date, new Date(2013, 0, 1, 0, 0, 0, 0)), +date, 'max')
 assert.equal(+dateMath.min(date, new Date(2015, 0, 1, 0, 0, 0, 0)), +date, 'min')


### PR DESCRIPTION
On subtracting more than 12 months, the value might still be negative after adding 12, at which point a spurious rollover adjustment may occur.

The adjusted value did not take the current/newMonth into account, only the number added/subtracted.

Performing the computation on both sides in the assertion might not be in line with your test conventions, but I feel that this provided the clearest expression of the issue.
