### PR TITLE
Take daylight saving time into account when perform diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var dates = module.exports = {
       case DAY:
         return dates.date(date, dates.date(date) + num)
       case WEEK:
-        return dates.date(date, dates.date(date) + (7 * num)) 
+        return dates.date(date, dates.date(date) + (7 * num))
       case MONTH:
         return monthMath(date, num)
       case DECADE:
@@ -61,13 +61,13 @@ var dates = module.exports = {
           date = dates.milliseconds(date, 0);
     }
 
-    if (unit === DECADE) 
+    if (unit === DECADE)
       date = dates.subtract(date, dates.year(date) % 10, 'year')
-    
-    if (unit === CENTURY) 
+
+    if (unit === CENTURY)
       date = dates.subtract(date, dates.year(date) % 100, 'year')
 
-    if (unit === WEEK) 
+    if (unit === WEEK)
       date = dates.weekday(date, 0, firstOfWeek);
 
     return date
@@ -96,7 +96,7 @@ var dates = module.exports = {
   max: function(){
     return new Date(Math.max.apply(Math, arguments))
   },
-  
+
   inRange: function(day, min, max, unit){
     unit = unit || 'day'
 
@@ -114,13 +114,13 @@ var dates = module.exports = {
   year:           createAccessor('FullYear'),
 
   decade: function (date, val) {
-    return val === undefined 
+    return val === undefined
       ? dates.year(dates.startOf(date, DECADE))
       : dates.add(date, val + 10, YEAR);
   },
 
   century: function (date, val) {
-    return val === undefined 
+    return val === undefined
       ? dates.year(dates.startOf(date, CENTURY))
       : dates.add(date, val + 100, YEAR);
   },
@@ -128,8 +128,8 @@ var dates = module.exports = {
   weekday: function (date, val, firstDay) {
       var weekday = (dates.day(date) + 7 - (firstDay || 0) ) % 7;
 
-      return val === undefined 
-        ? weekday 
+      return val === undefined
+        ? weekday
         : dates.add(date, val - weekday, DAY);
   },
 
@@ -180,13 +180,9 @@ var dates = module.exports = {
 
     result = dividend / divisor;
 
-    return asFloat ? result : absoluteFloor(result);
+    return asFloat ? result : Math.round(result);
   }
 };
-
-function absoluteFloor(number) {
-  return number < 0 ? Math.ceil(number) : Math.floor(number);
-}
 
 function monthMath(date, val){
   var current = dates.month(date)
@@ -195,7 +191,7 @@ function monthMath(date, val){
     date = dates.month(date, newMonth)
 
     while (newMonth < 0 ) newMonth = 12 + newMonth
-      
+
     //month rollover
     if ( dates.month(date) !== ( newMonth % 12))
       date = dates.date(date, 0) //move to last of month

--- a/test.js
+++ b/test.js
@@ -10,6 +10,24 @@ var date = new Date(
     , 30   /* sec */
     , 5);  /* ms */
 
+var beforeDaylightSavingTime = new Date(
+      2017 /* year */
+    , 2    /* month */
+    , 25   /* day */
+    , 12    /* hour */
+    , 0   /* min */
+    , 0   /* sec */
+    , 0);  /* ms */
+
+var afterDaylightSavingTime = new Date(
+      2017 /* year */
+    , 2    /* month */
+    , 26   /* day */
+    , 12    /* hour */
+    , 0   /* min */
+    , 0   /* sec */
+    , 0);  /* ms */
+
 console.log('---- Accessors ----------------------------')
 //accessors
 assert.equal(dateMath.year(date), 2014, 'year is equal to 2014')
@@ -77,6 +95,7 @@ assert.equal(dateMath.diff(dateMath.subtract(date, 12, 'minutes'), date, 'minute
 assert.equal(dateMath.diff(dateMath.subtract(date, 2, 'hours'), date, 'minutes'), 120)
 assert.equal(dateMath.diff(dateMath.subtract(date, 2, 'hours'), date, 'hours'), 2)
 assert.equal(dateMath.diff(dateMath.subtract(date, 1, 'day'), date, 'day'), 1)
+assert.equal(dateMath.diff(beforeDaylightSavingTime, afterDaylightSavingTime, 'day'), 1)
 assert.equal(dateMath.diff(dateMath.subtract(date, 125, 'month'), date, 'month'), 125)
 assert.equal(dateMath.diff(dateMath.subtract(date, 125, 'month'), date, 'year'), 10)
 assert.equal(dateMath.diff(date, dateMath.subtract(date, 125, 'month'), 'year'), -10)


### PR DESCRIPTION
If you calculate a difference in days between two dates that are in different time zones, because of daylight saving time switch, you get something like 23 hours of difference instead of 1 day. Because of the floor function, we counted 23 hours as 0 days, now we perform round and getting 1 day instead, as it should be.

As in test, the dates that were used are: 25.03.2017 - 26.03.2017. Gives us 0 days with previous implementation and 1 day difference with the changes that were introduced.
