### PR TITLE
Updated createAccessor to fix DST bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,13 +200,34 @@ function monthMath(date, val){
 }
 
 function createAccessor(method){
+  var hourLength = (function(method) {  
+    switch(method) {
+      case 'Milliseconds':
+        return 3600000;
+      case 'Seconds':
+        return 3600;
+      case 'Minutes':
+        return 60;
+      case 'Hours':
+        return 1;
+      default:
+        return -1;
+    }
+  })(method);
+  
   return function(date, val){
     if (val === undefined)
       return date['get' + method]()
 
-    date = new Date(date)
-    date['set' + method](val)
-    return date
+    dateOut = new Date(date)
+    dateOut['set' + method](val)
+    
+    if(dateOut['get'+method]() != val && (method === 'Hours' || val >=hourLength && (dateOut.getHours()-date.getHours()<Math.floor(val/hourLength))) ){
+      //Skip DST hour, if it occurs
+      dateOut['set'+method](val+hourLength);
+    }
+    
+    return dateOut
   }
 }
 


### PR DESCRIPTION
CreateAccessor changed to account for Date.set<Unit> working strangely during DST. Fixes DateTimePicker in react-widgets.

See [here](https://github.com/jquense/react-widgets/issues/739) for a bit more discussion.

I'm thinking this is the best way of detecting the bug happening, but I'm a tad worried about unintended side effects. Thoughts?